### PR TITLE
Fix DnD-kit import

### DIFF
--- a/frontend/src/components/cloud-costs.tsx
+++ b/frontend/src/components/cloud-costs.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import { Button, Card, CardBody, Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Input, Spinner, Tabs, Tab, useDisclosure } from "@heroui/react";
 import { Icon } from "@iconify/react";
-import { 
-  DndContext, 
-  closestCenter, 
-  KeyboardSensor, 
-  PointerSensor, 
-  useSensor, 
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
   useSensors,
-  DragEndEvent,
-  DragStartEvent,
   DragOverlay
 } from '@dnd-kit/core';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import {
   arrayMove,
   SortableContext,


### PR DESCRIPTION
## Summary
- import DragEndEvent and DragStartEvent as type-only to avoid runtime error

## Testing
- `node -v`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685d3cd23f3c832ba08502355fbd4a91